### PR TITLE
Backported fixes from fbmenugen

### DIFF
--- a/jwmappmenugen
+++ b/jwmappmenugen
@@ -106,7 +106,7 @@ my $config_help = <<"HELP";
                             ],
 
     | icon_dirs_second    : Look in this directories after looked in the directories of the
-                            current icons theme. (Before /usr/share/pixmaps)
+                            current icon theme. (Before /usr/share/pixmaps)
                             Example: [
                                 "/usr/share/icons/gnome",
                             ],
@@ -118,33 +118,31 @@ my $config_help = <<"HELP";
                                 "/usr/share/icons/Tango",
                             ],
 
-    | strict_icon_dirs    : A true value will make the module to look only inside the directories
-                            specified by you in either one of the above tree options.
+    | strict_icon_dirs    : A true value will make the script to look only inside the directories
+                            specified by you in either one of the above three options.
 
     | gtk_rc_filename     : Absolute path to the GTK configuration file.
-    | missing_image       : Use this icon for a missing icons (default: gtk-missing-image)
+    | missing_image       : Use this icon for missing icons (default: gtk-missing-image)
 
 
 || KEYS
-    | tooltip_keys        : Valid keys for the tooltip text.
-                            Example: ['Comment[es]', 'Comment'],
-
     | name_keys           : Valid keys for the item names.
                             Example: ['Name[fr]', 'GenericName[fr]', 'Name'],   # french menu
 
 
 || PATHS
-    | desktop_files_paths   : Absolute paths which contains .desktop files.
+    | desktop_files_paths   : Absolute paths which contain .desktop files.
                               Example: [
                                 '/usr/share/applications',
                                 "\$ENV{HOME}/.local/share/applications",
                                 glob("\$ENV{HOME}/.local/share/applications/wine/Programs/*"),
                               ],
 
+
 || NOTES
     | Regular expressions:
         * use qr/RE/ instead of 'RE'
-        * use qr/RE/i for case insenstive mode
+        * use qr/RE/i for case insensitive mode
 HELP
 
 my $schema_help = <<"HELP";
@@ -229,7 +227,7 @@ my $config_documentation = <<"EOD";
 #!/usr/bin/perl
 
 # $pkgname - configuration file
-# This file will be updated automatically every time when is needed.
+# This file will be updated automatically.
 # Any additional comment and/or indentation will be lost.
 
 =for comment
@@ -252,7 +250,7 @@ my %CONFIG = (
         terminalize            => 1,
         terminalization_format => q{%s -e '%s'},
 
-        desktop_files_paths => ['/usr/share/applications'],
+        desktop_files_paths => ['/usr/share/applications', '/usr/local/share/applications'],
 
         icon_dirs_first  => undef,
         icon_dirs_second => undef,
@@ -344,12 +342,9 @@ SCHEMA_FILE
 
 require $schema_file;    # Load the configuration files
 
-# Remove user's defined values
-#my @valid_keys = grep exists $CONFIG{$_}, keys $CONFIG;
-#@CONFIG{@valid_keys} = @{$CONFIG}{@valid_keys};
-
-# Keep user's defined values
-#@CONFIG{keys %{$CONFIG}} = values %{$CONFIG};
+# Remove invalid user-defined keys
+my @valid_keys = grep exists $CONFIG{$_}, keys %$CONFIG;
+@CONFIG{@valid_keys} = @{$CONFIG}{@valid_keys};
 
 if ($CONFIG{VERSION} != $version) {
     $update_config = 1;
@@ -372,7 +367,6 @@ my $desk_obj = Linux::DesktopFiles->new(
     : (),
 
     terminal              => $CONFIG{terminal},
-    keep_empty_categories => 0,
     case_insensitive_cats => 1,
                                        );
 
@@ -428,7 +422,7 @@ foreach my $schema (@$SCHEMA) {
                  my $exec = $_->{Exec};
 
                  foreach my $key (@{$CONFIG{name_keys}}) {
-                     if (defined $_->{$key}) {
+                     if ($_->{$key}) {
                          $name = $_->{$key};
                          last;
                      }


### PR DESCRIPTION
- Fixed the configuration system.
- Added `'/usr/local/share/applications'` to `desktop_files_paths`.
- Removed the no-op config key `keep_empty_categories` (this feature has been removed from Linux::DesktopFiles).
- Typo fixes.